### PR TITLE
Added missing comma

### DIFF
--- a/website/public/locales/de.json
+++ b/website/public/locales/de.json
@@ -47,7 +47,7 @@
     "titleFile": "Datei heruntergeladen",
     "titleMessage": "Entschlüsselte Nachricht",
     "subtitleMessage": "Dieses Geheimnis ist möglicherweise nur einmal lesbar. Bitte jetzt sichern!",
-    "buttonCopy": "Kopieren"
+    "buttonCopy": "Kopieren",
     "showQrCode": "QR-Code anzeigen",
     "hideQrCode": "QR-Code ausblenden"
   },


### PR DESCRIPTION
Fix JSON schema by adding a missing comma after `buttonCopy` value.